### PR TITLE
Add dockerfile for node server

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["node", "app.js"]


### PR DESCRIPTION
Allows for running the node server in a docker container. This container is probably what will be put on AWS. 